### PR TITLE
always use go-bindata, including in test

### DIFF
--- a/commands/bindata/bindata.go
+++ b/commands/bindata/bindata.go
@@ -91,7 +91,7 @@ func TemplatesClient_helper_resourceTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "../templates/client_helper_resource.tmpl", size: 959, mode: os.FileMode(420), modTime: time.Unix(1455546557, 0)}
+	info := bindataFileInfo{name: "../templates/client_helper_resource.tmpl", size: 959, mode: os.FileMode(420), modTime: time.Unix(1455590182, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -111,7 +111,7 @@ func TemplatesClient_resourceTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "../templates/client_resource.tmpl", size: 2189, mode: os.FileMode(420), modTime: time.Unix(1455546557, 0)}
+	info := bindataFileInfo{name: "../templates/client_resource.tmpl", size: 2189, mode: os.FileMode(420), modTime: time.Unix(1455590182, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -131,7 +131,7 @@ func TemplatesGeneric_mainTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "../templates/generic_main.tmpl", size: 73, mode: os.FileMode(420), modTime: time.Unix(1455091190, 0)}
+	info := bindataFileInfo{name: "../templates/generic_main.tmpl", size: 73, mode: os.FileMode(420), modTime: time.Unix(1455590182, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -151,7 +151,7 @@ func TemplatesPython_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "../templates/python_client.tmpl", size: 558, mode: os.FileMode(420), modTime: time.Unix(1455546557, 0)}
+	info := bindataFileInfo{name: "../templates/python_client.tmpl", size: 558, mode: os.FileMode(420), modTime: time.Unix(1455590182, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -171,7 +171,7 @@ func TemplatesPython_client_utilsTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "../templates/python_client_utils.tmpl", size: 237, mode: os.FileMode(420), modTime: time.Unix(1455546557, 0)}
+	info := bindataFileInfo{name: "../templates/python_client_utils.tmpl", size: 237, mode: os.FileMode(420), modTime: time.Unix(1455590182, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -191,7 +191,7 @@ func TemplatesServer_mainTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "../templates/server_main.tmpl", size: 315, mode: os.FileMode(420), modTime: time.Unix(1455091190, 0)}
+	info := bindataFileInfo{name: "../templates/server_main.tmpl", size: 315, mode: os.FileMode(420), modTime: time.Unix(1455590182, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -211,7 +211,7 @@ func TemplatesServer_resources_apiTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "../templates/server_resources_api.tmpl", size: 727, mode: os.FileMode(420), modTime: time.Unix(1455546557, 0)}
+	info := bindataFileInfo{name: "../templates/server_resources_api.tmpl", size: 727, mode: os.FileMode(420), modTime: time.Unix(1455590182, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -231,7 +231,7 @@ func TemplatesServer_resources_interfaceTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "../templates/server_resources_interface.tmpl", size: 497, mode: os.FileMode(420), modTime: time.Unix(1455546557, 0)}
+	info := bindataFileInfo{name: "../templates/server_resources_interface.tmpl", size: 497, mode: os.FileMode(420), modTime: time.Unix(1455590182, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -251,7 +251,7 @@ func TemplatesStructTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "../templates/struct.tmpl", size: 239, mode: os.FileMode(420), modTime: time.Unix(1455546557, 0)}
+	info := bindataFileInfo{name: "../templates/struct.tmpl", size: 239, mode: os.FileMode(420), modTime: time.Unix(1455590182, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/commands/body_gen_test.go
+++ b/commands/body_gen_test.go
@@ -10,7 +10,6 @@ import (
 
 func TestGenerateStructBodyFromRaml(t *testing.T) {
 	Convey("generate struct body from raml", t, func() {
-		testMode = true
 		apiDef, err := raml.ParseFile("./fixtures/struct.raml")
 		So(err, ShouldBeNil)
 

--- a/commands/client_gen_test.go
+++ b/commands/client_gen_test.go
@@ -9,7 +9,6 @@ import (
 
 func TestGenerateClientFromRaml(t *testing.T) {
 	Convey("generate client from raml", t, func() {
-		testMode = true
 		apiDef, err := raml.ParseFile("./fixtures/client_resources/client.raml")
 		So(err, ShouldBeNil)
 

--- a/commands/client_python_gen_test.go
+++ b/commands/client_python_gen_test.go
@@ -9,7 +9,6 @@ import (
 
 func TestGeneratePythonClientFromRaml(t *testing.T) {
 	Convey("generate python client", t, func() {
-		testMode = true
 		apiDef, err := raml.ParseFile("./fixtures/python_client/client.raml")
 		So(err, ShouldBeNil)
 

--- a/commands/command.go
+++ b/commands/command.go
@@ -1,9 +1,5 @@
 package commands
 
-var (
-	testMode = false
-)
-
 //Command is a toplevel command to be executed by the cli's main routine
 type Command interface {
 	//Execute the command

--- a/commands/resources_gen.go
+++ b/commands/resources_gen.go
@@ -78,7 +78,7 @@ func newInterfaceMethod(r *raml.Resource, rd *resourceDef, m *raml.Method, metho
 
 		for _, v := range splittedDesc {
 			tmpDesc += v + " "
-			if len(tmpDesc) > 80 {
+			if len(tmpDesc) > maxCommentPerLine {
 				results = append(results, tmpDesc+"\n")
 				tmpDesc = ""
 			}

--- a/commands/server_main_test.go
+++ b/commands/server_main_test.go
@@ -10,7 +10,6 @@ import (
 
 func TestServer(t *testing.T) {
 	Convey("server generator", t, func() {
-		testMode = true
 		Convey("simple server", func() {
 			apiDef, err := raml.ParseFile("./fixtures/server/user_api/api.raml")
 			So(err, ShouldBeNil)

--- a/commands/server_main_test.go
+++ b/commands/server_main_test.go
@@ -48,3 +48,7 @@ func TestServer(t *testing.T) {
 		})
 	})
 }
+
+func cleanTestingDir() {
+	os.RemoveAll("./test")
+}

--- a/commands/server_resources_gen_test.go
+++ b/commands/server_resources_gen_test.go
@@ -15,7 +15,6 @@ func testLoadFile(filename string) (string, error) {
 }
 func TestResource(t *testing.T) {
 	Convey("resource generator", t, func() {
-		testMode = true
 		Convey("simple resource", func() {
 			apiDef, err := raml.ParseFile("./fixtures/server_resources/deliveries.raml")
 			So(err, ShouldBeNil)

--- a/commands/struct_test.go
+++ b/commands/struct_test.go
@@ -9,7 +9,6 @@ import (
 
 func TestGenerateStructFromRaml(t *testing.T) {
 	Convey("generate struct from raml", t, func() {
-		testMode = true
 		apiDef, err := raml.ParseFile("./fixtures/struct.raml")
 		So(err, ShouldBeNil)
 

--- a/commands/test_utils.go
+++ b/commands/test_utils.go
@@ -1,9 +1,0 @@
-package commands
-
-import (
-	"os"
-)
-
-func cleanTestingDir() {
-	os.RemoveAll("./test")
-}

--- a/commands/utils.go
+++ b/commands/utils.go
@@ -107,22 +107,14 @@ func generateFile(data interface{}, tmplFile, tmplName, filename string, overrid
 		"ToLower": strings.ToLower,
 	}
 
-	var t *template.Template
-	var err error
-
-	if testMode {
-		t, err = template.New(tmplName).Funcs(funcMap).ParseFiles(tmplFile)
-	} else {
-		tmplFile = strings.Replace(tmplFile, "./", "../", -1)
-		data, err := bindata.Asset(tmplFile)
-		if err != nil {
-			return err
-		}
-
-		//get string from byte
-		t, err = template.New(tmplName).Funcs(funcMap).Parse(string(data))
+	tmplFile = strings.Replace(tmplFile, "./", "../", -1)
+	byteData, err := bindata.Asset(tmplFile)
+	if err != nil {
+		return err
 	}
 
+	//get string from byte
+	t, err := template.New(tmplName).Funcs(funcMap).Parse(string(byteData))
 	if err != nil {
 		return err
 	}

--- a/commands/utils.go
+++ b/commands/utils.go
@@ -37,6 +37,7 @@ func normalizeBracket(URI string) string {
 	return strings.Replace(normalizeLeftBracket, "}", "", -1)
 }
 
+/*
 func _completeResourceURI(r *raml.Resource, completeURI string) string {
 	if r == nil {
 		return completeURI
@@ -48,6 +49,7 @@ func _completeResourceURI(r *raml.Resource, completeURI string) string {
 func completeResourceURI(r *raml.Resource) string {
 	return _completeResourceURI(r, "")
 }
+*/
 
 func _getResourceParams(r *raml.Resource, params []string) []string {
 	if r == nil {


### PR DESCRIPTION
We previously only use go-bindata in the executable, not in the test.

We sometimes forget to update the executable, resulting in issue #11.

This patch solve this issue by always using go-bindata in executable & tests.