### PR TITLE
Fix for not able to open result directory

### DIFF
--- a/commands/body_gen.go
+++ b/commands/body_gen.go
@@ -9,11 +9,6 @@ const (
 
 // generate Go struct from RAML definition
 func generateBodyStructs(apiDef *raml.APIDefinition, dir, packageName string) error {
-	// check create dir
-	if err := checkCreateDir(dir); err != nil {
-		return err
-	}
-
 	// generate
 	for _, v := range apiDef.Resources {
 		if err := generateStructsFromResourceBody("", dir, packageName, &v); err != nil {

--- a/commands/server_main_gen.go
+++ b/commands/server_main_gen.go
@@ -37,6 +37,11 @@ func (sd serverDef) generate(dir, lang string) error {
 
 // generate API server files
 func generateServer(apiDef *raml.APIDefinition, dir, packageName, lang string, generateMain bool) error {
+
+	if err := checkCreateDir(dir); err != nil {
+		return err
+	}
+
 	if lang == "go" {
 		// generate struct validator
 		if err := generateInputValidator(packageName, dir); err != nil {

--- a/commands/struct.go
+++ b/commands/struct.go
@@ -132,9 +132,6 @@ func (sd structDef) generate(dir string) error {
 
 // generate all structs from an RAML api definition
 func generateStructs(apiDefinition *raml.APIDefinition, dir string, packageName string) error {
-	if err := checkCreateDir(dir); err != nil {
-		return err
-	}
 	for k, v := range apiDefinition.Types {
 		sd := newStructDefFromType(v, k, packageName, v.Description)
 		if err := sd.generate(dir); err != nil {


### PR DESCRIPTION
Introduction of validators introduced a bug where go-raml trying
to open a file in directory which is not yet available.
Moved checkCreateDir() to generateServer() to prevent:
1. Re-checking on each generation
2. Further bugs with no directory available