### PR TITLE
set proper package name in oauth2 go client

### DIFF
--- a/codegen/golang/client.go
+++ b/codegen/golang/client.go
@@ -126,6 +126,7 @@ func (c *Client) generateSecurity(dir string) error {
 			ctx := map[string]string{
 				"ClientName":     c.Name,
 				"AccessTokenURI": fmt.Sprintf("%v", v),
+				"PackageName":    c.PackageName,
 			}
 			filename := filepath.Join(dir, "oauth2_client_"+name+".go")
 			if err := commons.GenerateFile(ctx, "./templates/oauth2_client_go.tmpl", "oauth2_client_go", filename, true); err != nil {

--- a/codegen/templates/oauth2_client_go.tmpl
+++ b/codegen/templates/oauth2_client_go.tmpl
@@ -1,5 +1,5 @@
 {{- define "oauth2_client_go" -}}
-package main
+package {{.PackageName}}
 
 import (
 	"fmt"


### PR DESCRIPTION
In the file `oauth2_client_itsyouonline.go` the package name generated was always master. This prevent the client to compile when using a user defined package name.

This PR set the package name in this file too