### PR TITLE
Handle field with dash in go.

### DIFF
--- a/codegen/fixtures/struct/struct.raml
+++ b/codegen/fixtures/struct/struct.raml
@@ -44,6 +44,11 @@ types:
     properties:
       name:
         type: string
+  Dashed:
+    properties:
+      Dashed-Field:
+        type: string
+
   Cat:
     properties:
       kind:

--- a/codegen/golang/field.go
+++ b/codegen/golang/field.go
@@ -21,7 +21,7 @@ type fieldDef struct {
 
 func newFieldDef(structName string, prop raml.Property, pkg string) fieldDef {
 	fd := fieldDef{
-		Name:      strings.Title(prop.Name),
+		Name:      formatFieldName(prop.Name),
 		Type:      convertToGoType(prop.Type),
 		IsOmitted: !prop.Required,
 	}
@@ -82,4 +82,12 @@ func (fd *fieldDef) buildValidators(p raml.Property) {
 	if validators != "" {
 		fd.Validators = validators[1:]
 	}
+}
+
+// format struct's field name
+// - Title it
+// - replace '-' with '_'
+func formatFieldName(name string) string {
+	formatted := strings.Replace(name, "-", "_", -1)
+	return strings.Title(formatted)
 }

--- a/codegen/golang/fixtures/struct/Dashed.txt
+++ b/codegen/golang/fixtures/struct/Dashed.txt
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"gopkg.in/validator.v2"
+)
+
+type Dashed struct {
+	Dashed_Field string `json:"Dashed-Field" validate:"nonzero"`
+}
+
+func (s Dashed) Validate() error {
+
+	return validator.Validate(s)
+}

--- a/codegen/golang/struct_test.go
+++ b/codegen/golang/struct_test.go
@@ -41,6 +41,7 @@ func TestGenerateStructFromRaml(t *testing.T) {
 				{"animal.go", "animal.txt"},                     // using enum
 				{"EnumString.go", "enumstring.txt"},             // Enum type
 				{"ValidationString.go", "ValidationString.txt"}, // validation
+				{"Dashed.go", "Dashed.txt"},                     // field with dash
 			}
 
 			for _, check := range checks {


### PR DESCRIPTION
replace `-` with `_` in Go field name.

example case: https://github.com/g8os/grid/blob/5159e6190dfc0f41de604897a5e5708d9db66fa9/raml/api.raml#L93

No replacement in Nim and Python because we currently have no way to specify json field name on those languages.