### PR TITLE
using Jsonschema to define new type

### DIFF
--- a/codegen/fixtures/struct/json/api.raml
+++ b/codegen/fixtures/struct/json/api.raml
@@ -3,6 +3,9 @@ title: Using JSON Schema
 
 types:
   PersonInclude: !include person.json
+  PersonInType:
+    description: description not in json
+    type: !include person.json
 
 /person:
   get:

--- a/codegen/fixtures/struct/json/person.json
+++ b/codegen/fixtures/struct/json/person.json
@@ -14,5 +14,5 @@
       "minimum": 0
     }
   },
-  "required": ["firstName", "lastName"]
+  "required": ["firstName"]
 }

--- a/codegen/golang/fixtures/struct/json/PersonInType.txt
+++ b/codegen/golang/fixtures/struct/json/PersonInType.txt
@@ -4,13 +4,14 @@ import (
 	"gopkg.in/validator.v2"
 )
 
-type PersonGetRespBody struct {
+// description not in json
+type PersonInType struct {
 	Age       int    `json:"age,omitempty" validate:"min=0"`
 	FirstName string `json:"firstName" validate:"nonzero"`
 	LastName  string `json:"lastName,omitempty"`
 }
 
-func (s PersonGetRespBody) Validate() error {
+func (s PersonInType) Validate() error {
 
 	return validator.Validate(s)
 }

--- a/codegen/golang/fixtures/struct/json/PersonPostReqBody.txt
+++ b/codegen/golang/fixtures/struct/json/PersonPostReqBody.txt
@@ -5,8 +5,8 @@ import (
 )
 
 type PersonPostReqBody struct {
-	FirstName string `json:"firstName" validate:"nonzero"`
-	LastName  string `json:"lastName" validate:"nonzero"`
+	FirstName string `json:"firstName,omitempty"`
+	LastName  string `json:"lastName,omitempty"`
 }
 
 func (s PersonPostReqBody) Validate() error {

--- a/codegen/golang/struct.go
+++ b/codegen/golang/struct.go
@@ -82,9 +82,9 @@ func newStructDefFromBody(body *raml.Bodies, structNamePrefix, packageName strin
 	//					}
 	//				}
 	if body.ApplicationJSON.TypeString() != "" {
-		var t raml.Type
-		if err := json.Unmarshal([]byte(body.ApplicationJSON.TypeString()), &t); err == nil {
-			return newStructDefFromType(t, structName, packageName)
+		var js raml.JSONSchema
+		if err := json.Unmarshal([]byte(body.ApplicationJSON.TypeString()), &js); err == nil {
+			return newStructDef(structName, packageName, js.Description, js.RAMLProperties())
 		}
 	}
 	return newStructDef(structName, packageName, "", body.ApplicationJSON.Properties)

--- a/codegen/golang/struct_test.go
+++ b/codegen/golang/struct_test.go
@@ -67,20 +67,18 @@ func TestGenerateStructFromRaml(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			rootFixture := "./fixtures/struct/json"
-			checks := []struct {
-				Result   string
-				Expected string
-			}{
-				{"PersonInclude.go", "PersonInclude.txt"},
-				{"PersonPostReqBody.go", "PersonPostReqBody.txt"},
-				{"PersonGetRespBody.go", "PersonGetRespBody.txt"},
+			files := []string{
+				"PersonInclude",
+				"PersonPostReqBody",
+				"PersonGetRespBody",
+				"PersonInType",
 			}
 
-			for _, check := range checks {
-				s, err := testLoadFile(filepath.Join(targetDir, check.Result))
+			for _, f := range files {
+				s, err := testLoadFile(filepath.Join(targetDir, f+".go"))
 				So(err, ShouldBeNil)
 
-				tmpl, err := testLoadFile(filepath.Join(rootFixture, check.Expected))
+				tmpl, err := testLoadFile(filepath.Join(rootFixture, f+".txt"))
 				So(err, ShouldBeNil)
 
 				So(s, ShouldEqual, tmpl)

--- a/codegen/nim/fixtures/object/json/personGetRespBody.nim
+++ b/codegen/nim/fixtures/object/json/personGetRespBody.nim
@@ -1,6 +1,6 @@
 
 type
   personGetRespBody* = object
-    age*: string
+    age*: int
     firstName*: string
     lastName*: string

--- a/codegen/nim/object.go
+++ b/codegen/nim/object.go
@@ -115,9 +115,9 @@ func generateObjectFromBody(methodName string, body *raml.Bodies, isReq bool, di
 // create new object from a method body
 func newObjectFromBody(methodName string, body *raml.Bodies, isReq bool) (object, error) {
 	if body.ApplicationJSON.TypeString() != "" {
-		var t raml.Type
-		if err := json.Unmarshal([]byte(body.ApplicationJSON.TypeString()), &t); err == nil {
-			return newObjectFromType(t, methodName)
+		var js raml.JSONSchema
+		if err := json.Unmarshal([]byte(body.ApplicationJSON.TypeString()), &js); err == nil {
+			return newObject(methodName, "", js.RAMLProperties())
 		}
 	}
 

--- a/codegen/python/jsonschema/jsonschema.go
+++ b/codegen/python/jsonschema/jsonschema.go
@@ -1,185 +1,21 @@
 package jsonschema
 
 import (
-	"encoding/json"
-	"fmt"
 	"path/filepath"
-	"sort"
 
 	"github.com/Jumpscale/go-raml/codegen/commons"
 	"github.com/Jumpscale/go-raml/raml"
 )
 
 const (
-	schemaVer  = "http://json-schema.org/schema#"
 	fileSuffix = "_schema.json"
 )
 
-var (
-	scalarTypes = map[string]bool{
-		"string":  true,
-		"number":  true,
-		"boolean": true,
-		"integer": true,
-	}
-)
-
-// JSONSchema represents a json-schema json file
-type JSONSchema struct {
-	Schema     string              `json:"$schema"`
-	Name       string              `json:"-"`
-	Type       string              `json:"type"`
-	Items      *arrayItem          `json:"items,omitempty"`
-	Properties map[string]property `json:"properties,omitempty"`
-	Required   []string            `json:"required,omitempty"`
-
-	// Array properties
-	MinItems    int  `json:"minItems,omitempty"`
-	MaxItems    int  `json:"maxItems,omitempty"`
-	UniqueItems bool `json:"uniqueItems,omitempty"`
-}
-
-// NewJSONSchema creates JSON schema from an raml type
-func NewJSONSchema(t raml.Type, name string) JSONSchema {
-	typ := fmt.Sprintf("%v", t.Type)
-	if typ == "" || t.Type == nil {
-		typ = "object"
-	}
-
-	return newJSONSchemaFromProps(&t, t.Properties, typ, name)
-}
-
-// NewJSONSchemaFromBodies creates JSON schema from raml bodies
-func NewJSONSchemaFromBodies(b raml.Bodies, name string) JSONSchema {
-	if b.ApplicationJSON.Type != "" {
-		var t raml.Type
-		if err := json.Unmarshal([]byte(b.ApplicationJSON.TypeString()), &t); err == nil {
-			return NewJSONSchema(t, name)
-		}
-	}
-	return newJSONSchemaFromProps(nil, b.ApplicationJSON.Properties, "object", name)
-}
-
-// newJSONSchemaFromProps creates json schmema
-// from a map of properties
-func newJSONSchemaFromProps(t *raml.Type, properties map[string]interface{}, typ, name string) JSONSchema {
-	var required []string
-
-	if isTypeArray(typ) {
-		return newArraySchema(t, typ, name)
-	}
-
-	props := make(map[string]property, len(properties))
-	for k, v := range properties {
-		rp := raml.ToProperty(k, v)
-		if !isPropTypeSupported(rp) {
-			continue
-		}
-
-		p := newProperty(rp)
-		props[p.Name] = p
-		if p.Required {
-			required = append(required, p.Name)
-		}
-	}
-
-	// we need it to be sorted for testing purpose
-	sort.Strings(required)
-	return JSONSchema{
-		Schema:     schemaVer,
-		Name:       name,
-		Type:       typ,
-		Properties: props,
-		Required:   required,
-	}
-}
-
-// Supported returns true if the type is supported
-func (js JSONSchema) Supported() bool {
-	return js.Type == "object" || js.Type == "array"
-}
-func (js JSONSchema) String() string {
-	// for unsupported type, force the type to `object` type
-	if !js.Supported() {
-		js.Type = "object"
-	}
-
-	b, err := json.MarshalIndent(&js, "", "\t")
-	if err != nil {
-		return "{}"
-	}
-	return string(b)
-}
-
 // Generate generates a json file of this schema
-func (js JSONSchema) Generate(dir string) error {
+func Generate(js raml.JSONSchema, dir string) error {
 	filename := filepath.Join(dir, js.Name+fileSuffix)
 	ctx := map[string]interface{}{
 		"Content": js.String(),
 	}
 	return commons.GenerateFile(ctx, "./templates/json_schema.tmpl", "json_schema", filename, false)
-}
-
-type property struct {
-	Name     string      `json:"-"`
-	Ref      string      `json:"$ref,omitempty"`
-	Type     string      `json:"type,omitempty"`
-	Required bool        `json:"-"`
-	Enum     interface{} `json:"enum,omitempty"`
-
-	// string
-	MinLength *int    `json:"minLength,omitempty"`
-	MaxLength *int    `json:"maxLength,omitempty"`
-	Pattern   *string `json:"pattern,omitempty"`
-
-	// number
-	Minimum    *float64 `json:"minimum,omitempty"`
-	Maximum    *float64 `json:"maximum,omitempty"`
-	MultipleOf *float64 `json:"multipleOf,omitempty"`
-
-	// array
-	MinItems    *int       `json:"minItems,omitempty"`
-	MaxItems    *int       `json:"maxItems,omitempty"`
-	UniqueItems bool       `json:"uniqueItems,omitempty"`
-	Items       *arrayItem `json:"items,omitempty"`
-}
-
-func newProperty(rp raml.Property) property {
-	_, isScalar := scalarTypes[rp.Type]
-
-	// complex type
-	if rp.Type != "" && !isScalar && !rp.IsArray() && !rp.IsBidimensiArray() {
-		return property{
-			Name:     rp.Name,
-			Ref:      rp.Type + fileSuffix,
-			Required: rp.Required,
-		}
-	}
-
-	p := property{
-		Name:        rp.Name,
-		Type:        rp.Type,
-		Required:    rp.Required,
-		Enum:        rp.Enum,
-		MinLength:   rp.MinLength,
-		MaxLength:   rp.MaxLength,
-		Pattern:     rp.Pattern,
-		Minimum:     rp.Minimum,
-		Maximum:     rp.Maximum,
-		MultipleOf:  rp.MultipleOf,
-		MinItems:    rp.MinItems,
-		MaxItems:    rp.MaxItems,
-		UniqueItems: rp.UniqueItems,
-	}
-
-	// array
-	if rp.IsArray() && !rp.IsBidimensiArray() {
-		p.Type = "array"
-		p.Items = newArrayItem(rp.ArrayType())
-	}
-	return p
-}
-
-func isPropTypeSupported(p raml.Property) bool {
-	return !p.IsBidimensiArray() && !p.IsUnion()
 }

--- a/codegen/python/jsonschema/jsonschema_test.go
+++ b/codegen/python/jsonschema/jsonschema_test.go
@@ -23,8 +23,8 @@ func TestGenerateStructFromRaml(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			for name, t := range apiDef.Types {
-				js := NewJSONSchema(t, name)
-				err := js.Generate(targetDir)
+				js := raml.NewJSONSchema(t, name)
+				err := Generate(js, targetDir)
 				So(err, ShouldBeNil)
 			}
 			rootFixture := "./fixtures/array_type"
@@ -54,8 +54,8 @@ func TestGenerateStructFromRaml(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			for name, t := range apiDef.Types {
-				js := NewJSONSchema(t, name)
-				err := js.Generate(targetDir)
+				js := raml.NewJSONSchema(t, name)
+				err := Generate(js, targetDir)
 				So(err, ShouldBeNil)
 			}
 			rootFixture := "./fixtures/simple"
@@ -83,8 +83,8 @@ func TestGenerateStructFromRaml(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			for name, t := range apiDef.Types {
-				js := NewJSONSchema(t, name)
-				err := js.Generate(targetDir)
+				js := raml.NewJSONSchema(t, name)
+				err := Generate(js, targetDir)
 				So(err, ShouldBeNil)
 			}
 			rootFixture := "./fixtures/struct"

--- a/codegen/python/sanic_jsonschema.go
+++ b/codegen/python/sanic_jsonschema.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Jumpscale/go-raml/codegen/commons"
 	"github.com/Jumpscale/go-raml/codegen/python/jsonschema"
+	"github.com/Jumpscale/go-raml/raml"
 )
 
 const (
@@ -27,8 +28,8 @@ func (s SanicServer) generateJSONSchema(dir string) error {
 
 func (s SanicServer) genJSONSchemaFromTypes(dir string) error {
 	for name, t := range s.APIDef.Types {
-		js := jsonschema.NewJSONSchema(t, name)
-		if err := js.Generate(dir); err != nil {
+		js := raml.NewJSONSchema(t, name)
+		if err := jsonschema.Generate(js, dir); err != nil {
 			return err
 		}
 	}
@@ -40,8 +41,8 @@ func (s SanicServer) genJSONSchemaFromMethods(dir string) error {
 	jsonSchemaFromMethod := func(m serverMethod) error {
 		if commons.HasJSONBody(&m.Bodies) {
 			name := inflect.UpperCamelCase(m.MethodName + "ReqBody")
-			js := jsonschema.NewJSONSchemaFromBodies(m.Bodies, name)
-			if err := js.Generate(dir); err != nil {
+			js := raml.NewJSONSchemaFromBodies(m.Bodies, name)
+			if err := jsonschema.Generate(js, dir); err != nil {
 				return err
 			}
 		}

--- a/raml/apidefinition.go
+++ b/raml/apidefinition.go
@@ -123,6 +123,12 @@ func (apiDef *APIDefinition) PostProcess(filename string) error {
 		apiDef.ResourceTypes[name] = rt
 	}
 
+	// types
+	for name, t := range apiDef.Types {
+		t.postProcess()
+		apiDef.Types[name] = t
+	}
+
 	// resources
 	for k := range apiDef.Resources {
 		r := apiDef.Resources[k]

--- a/raml/jsonschema.go
+++ b/raml/jsonschema.go
@@ -23,7 +23,7 @@ var (
 type JSONSchema struct {
 	Schema      string              `json:"$schema"`
 	Name        string              `json:"-"`
-	Description string              `json:"description"`
+	Description string              `json:"description,omitempty"`
 	Type        string              `json:"type"`
 	Items       *arrayItem          `json:"items,omitempty"`
 	Properties  map[string]property `json:"properties,omitempty"`

--- a/raml/jsonschema.go
+++ b/raml/jsonschema.go
@@ -1,0 +1,171 @@
+package raml
+
+import (
+	"encoding/json"
+	"sort"
+)
+
+const (
+	schemaVer  = "http://json-schema.org/schema#"
+	fileSuffix = "_schema.json"
+)
+
+var (
+	jsonScalarTypes = map[string]bool{
+		"string":  true,
+		"number":  true,
+		"boolean": true,
+		"integer": true,
+	}
+)
+
+// JSONSchema represents a json-schema json file
+type JSONSchema struct {
+	Schema     string              `json:"$schema"`
+	Name       string              `json:"-"`
+	Type       string              `json:"type"`
+	Items      *arrayItem          `json:"items,omitempty"`
+	Properties map[string]property `json:"properties,omitempty"`
+	Required   []string            `json:"required,omitempty"`
+
+	// Array properties
+	MinItems    int  `json:"minItems,omitempty"`
+	MaxItems    int  `json:"maxItems,omitempty"`
+	UniqueItems bool `json:"uniqueItems,omitempty"`
+}
+
+// NewJSONSchema creates JSON schema from an raml type
+func NewJSONSchema(t Type, name string) JSONSchema {
+	typ := t.TypeString()
+	if typ == "" || t.Type == nil {
+		typ = "object"
+	}
+
+	return newJSONSchemaFromProps(&t, t.Properties, typ, name)
+}
+
+// NewJSONSchemaFromBodies creates JSON schema from raml bodies
+func NewJSONSchemaFromBodies(b Bodies, name string) JSONSchema {
+	if b.ApplicationJSON.Type != "" {
+		var t Type
+		if err := json.Unmarshal([]byte(b.ApplicationJSON.TypeString()), &t); err == nil {
+			return NewJSONSchema(t, name)
+		}
+	}
+	return newJSONSchemaFromProps(nil, b.ApplicationJSON.Properties, "object", name)
+}
+
+// newJSONSchemaFromProps creates json schmema
+// from a map of properties
+func newJSONSchemaFromProps(t *Type, properties map[string]interface{}, typ, name string) JSONSchema {
+	var required []string
+
+	if isTypeArray(typ) {
+		return newArraySchema(t, typ, name)
+	}
+
+	props := make(map[string]property, len(properties))
+	for k, v := range properties {
+		rp := ToProperty(k, v)
+		if !isPropTypeSupported(rp) {
+			continue
+		}
+
+		p := newProperty(rp)
+		props[p.Name] = p
+		if p.Required {
+			required = append(required, p.Name)
+		}
+	}
+
+	// we need it to be sorted for testing purpose
+	sort.Strings(required)
+	return JSONSchema{
+		Schema:     schemaVer,
+		Name:       name,
+		Type:       typ,
+		Properties: props,
+		Required:   required,
+	}
+}
+
+// Supported returns true if the type is supported
+func (js JSONSchema) Supported() bool {
+	return js.Type == "object" || js.Type == "array"
+}
+func (js JSONSchema) String() string {
+	// for unsupported type, force the type to `object` type
+	if !js.Supported() {
+		js.Type = "object"
+	}
+
+	b, err := json.MarshalIndent(&js, "", "\t")
+	if err != nil {
+		return "{}"
+	}
+	return string(b)
+}
+
+type property struct {
+	Name     string      `json:"-"`
+	Ref      string      `json:"$ref,omitempty"`
+	Type     string      `json:"type,omitempty"`
+	Required bool        `json:"-"`
+	Enum     interface{} `json:"enum,omitempty"`
+
+	// string
+	MinLength *int    `json:"minLength,omitempty"`
+	MaxLength *int    `json:"maxLength,omitempty"`
+	Pattern   *string `json:"pattern,omitempty"`
+
+	// number
+	Minimum    *float64 `json:"minimum,omitempty"`
+	Maximum    *float64 `json:"maximum,omitempty"`
+	MultipleOf *float64 `json:"multipleOf,omitempty"`
+
+	// array
+	MinItems    *int       `json:"minItems,omitempty"`
+	MaxItems    *int       `json:"maxItems,omitempty"`
+	UniqueItems bool       `json:"uniqueItems,omitempty"`
+	Items       *arrayItem `json:"items,omitempty"`
+}
+
+func newProperty(rp Property) property {
+	_, isScalar := jsonScalarTypes[rp.Type]
+
+	// complex type
+	if rp.Type != "" && !isScalar && !rp.IsArray() && !rp.IsBidimensiArray() {
+		return property{
+			Name:     rp.Name,
+			Ref:      rp.Type + fileSuffix,
+			Required: rp.Required,
+		}
+	}
+
+	p := property{
+		Name:        rp.Name,
+		Type:        rp.Type,
+		Required:    rp.Required,
+		Enum:        rp.Enum,
+		MinLength:   rp.MinLength,
+		MaxLength:   rp.MaxLength,
+		Pattern:     rp.Pattern,
+		Minimum:     rp.Minimum,
+		Maximum:     rp.Maximum,
+		MultipleOf:  rp.MultipleOf,
+		MinItems:    rp.MinItems,
+		MaxItems:    rp.MaxItems,
+		UniqueItems: rp.UniqueItems,
+	}
+
+	// array
+	if rp.IsArray() && !rp.IsBidimensiArray() {
+		p.Type = "array"
+		p.Items = newArrayItem(rp.ArrayType())
+	}
+	return p
+}
+
+func isPropTypeSupported(p Property) bool {
+	return !p.IsBidimensiArray() && !p.IsUnion()
+}

--- a/raml/jsonschema_array.go
+++ b/raml/jsonschema_array.go
@@ -1,13 +1,11 @@
-package jsonschema
+package raml
 
 import (
 	"fmt"
-
-	"github.com/Jumpscale/go-raml/codegen/commons"
-	"github.com/Jumpscale/go-raml/raml"
+	"strings"
 )
 
-func newArraySchema(t *raml.Type, typ, name string) JSONSchema {
+func newArraySchema(t *Type, typ, name string) JSONSchema {
 	js := JSONSchema{
 		Name:   name,
 		Schema: schemaVer,
@@ -24,7 +22,8 @@ func newArraySchema(t *raml.Type, typ, name string) JSONSchema {
 }
 
 func isTypeArray(typ string) bool {
-	return typ == "array" || (commons.IsArray(typ) && !commons.IsBidimensiArray(typ))
+	t := Type{Type: typ}
+	return typ == "array" || (t.IsArray() && !t.IsBidimensiArray())
 }
 
 type arrayItem struct {
@@ -43,9 +42,9 @@ func newArrayItem(typ string) *arrayItem {
 	}
 }
 
-func getArrayItemsType(t *raml.Type, typ string) string {
+func getArrayItemsType(t *Type, typ string) string {
 	if typ == "array" {
 		return fmt.Sprint(t.Items)
 	}
-	return commons.ArrayType(typ)
+	return strings.TrimSuffix(typ, "[]")
 }

--- a/raml/types.go
+++ b/raml/types.go
@@ -534,7 +534,6 @@ type jsonType struct {
 
 // see if the 'Type' field is a JSON schema
 func (t *Type) postProcess() error {
-	fmt.Printf("post procsess\n")
 	if !t.IsJSONType() {
 		return nil
 	}


### PR DESCRIPTION
Fix #242 and bug regarding the usage of JSON to define RAML type. We should use [json schema](http://json-schema.org/) while previously we only use JSON (map JSON to YAML)