### PR TITLE
move api docs building into Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,6 @@ go:
   - 1.9
 
 script:
-  - ./build_apidocs.sh
+  - make apidocs
   - make install
   - make test

--- a/Makefile
+++ b/Makefile
@@ -6,5 +6,12 @@ install:
 	go generate
 	go install -v
 
+apidocs:
+	cd codegen/apidocs/html
+	rm -f ../apidocs_html.zip
+	zip -rq  ../apidocs_html.zip *
+	cd -
+	go-bindata -nometadata -pkg apidocs -prefix codegen/apidocs -o codegen/apidocs/apidocs_html_zip.go codegen/apidocs/apidocs_html.zip
+
 test:
 	go test $(PACKAGES)

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Install go-bindata, we need it to compile all resource files to .go file
 To rebuild APIDocs files to .go file
 ```
 cd $GOPATH/src/github.com/Jumpscale/go-raml
-sh build_apidocs.sh
+make apidocs
 ```
 
 Build go-raml and all resource files

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-go generate
-
-# build
-go install -v $(go list ./... | grep -v '/vendor/')

--- a/build_apidocs.sh
+++ b/build_apidocs.sh
@@ -1,4 +1,0 @@
-# apidocs.zip
-cd codegen/apidocs/html; rm -f ../apidocs_html.zip ; zip -rq  ../apidocs_html.zip *
-cd -
-go-bindata -nometadata -pkg apidocs -prefix codegen/apidocs -o codegen/apidocs/apidocs_html_zip.go codegen/apidocs/apidocs_html.zip

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -ex
-go get -u github.com/tools/godep
-go get -u github.com/jteeuwen/go-bindata/...
-go get -u github.com/Jumpscale/go-raml
-cd $GOPATH/src/github.com/Jumpscale/go-raml
-sh build.sh
-


### PR DESCRIPTION
now that we use the Makefile to build and install
also use it to build the build the api docs

this allow to remove the build_apidocs.sh file